### PR TITLE
Break ILifecycle into Startable and Stoppable

### DIFF
--- a/src/com/palletops/leaven.cljx
+++ b/src/com/palletops/leaven.cljx
@@ -17,7 +17,7 @@
   "Start a component."
   {:sig [[schema/Any :- schema/Any]]}
   [component]
-  (if (protocols/lifecycle? component)
+  (if (protocols/startable? component)
     (protocols/start component)
     component))
 
@@ -25,7 +25,7 @@
   "Stop a component."
   {:sig [[schema/Any :- schema/Any]]}
   [component]
-  (if (protocols/lifecycle? component)
+  (if (protocols/stoppable? component)
     (protocols/stop component)
     component))
 
@@ -33,20 +33,26 @@
   "Ask a component for its status."
   {:sig [[schema/Any :- schema/Any]]}
   [component]
-  (if (protocols/status? component)
+  (if (protocols/queryable? component)
     (protocols/status component)))
 
-(defn-api lifecycle?
-  "Predicate for testing whether `x` satisfies the ILifecycle protocol."
+(defn-api startable?
+  "Predicate for testing whether `x` satisfies the Startable protocol."
   {:sig [[schema/Any :- schema/Any]]}
   [x]
-  (protocols/lifecycle? x))
+  (protocols/startable? x))
 
-(defn-api status?
+(defn-api stoppable?
+  "Predicate for testing whether `x` satisfies the Stoppable protocol."
+  {:sig [[schema/Any :- schema/Any]]}
+  [x]
+  (protocols/stoppable? x))
+
+(defn-api queryable?
   "Predicate for testing whether `x` satisfies the IStatus protocol."
   {:sig [[schema/Any :- schema/Any]]}
   [x]
-  (protocols/status? x))
+  (protocols/queryable? x))
 
 (defn ^:internal apply-components
   "Execute a function on a sequence of components from a record.
@@ -93,11 +99,12 @@
     `(defrecord ~record-name
          [~@(map (comp symbol name) components)]
        ~@body
-       protocols/ILifecycle
+       protocols/Startable
        (~'start [component#]
          (apply-components start component# ~components "starting"))
+       protocols/Stoppable
        (~'stop [component#]
          (apply-components stop component# ~rcomponents "stopping"))
-       protocols/IStatus
+       protocols/Queryable
        (~'status [component#]
          (apply-components status component# ~rcomponents "querying status")))))

--- a/src/com/palletops/leaven/protocols.cljx
+++ b/src/com/palletops/leaven/protocols.cljx
@@ -1,25 +1,32 @@
 (ns com.palletops.leaven.protocols
   "Protocols for leaven components")
 
-(defprotocol ILifecycle
+(defprotocol Startable
   "Basic lifecycle for a component."
   (start [component]
-    "Start a component. Returns an updated component.")
+    "Start a component. Returns an updated component."))
+
+(defprotocol Stoppable
   (stop [component]
     "Stop a component. Returns an updated component."))
 
-(defn lifecycle?
-  "Predicate for testing whether `x` satisfies the ILifecycle protocol."
-  [x]
-  (satisfies? ILifecycle x))
-
-(defprotocol IStatus
+(defprotocol Queryable
   "Allows a component to implement a status function, which may just
   have side effects (like logging)."
   (status [component]
     "Allow a component to be queried for status."))
 
-(defn status?
+(defn startable?
+  "Predicate for testing whether `x` satisfies the Startable protocol."
+  [x]
+  (satisfies? Startable x))
+
+(defn stoppable?
+  "Predicate for testing whether `x` satisfies the Stoppable protocol."
+  [x]
+  (satisfies? Stoppable x))
+
+(defn queryable?
   "Predicate for testing whether `x` satisfies the IStatus protocol."
   [x]
-  (satisfies? IStatus x))
+  (satisfies? Queryable x))

--- a/src/com/palletops/leaven/schema.cljx
+++ b/src/com/palletops/leaven/schema.cljx
@@ -2,10 +2,13 @@
   "Optional schema support for leaven protocols."
   (:require
    [schema.core :as schema]
-   [com.palletops.leaven.protocols :refer [lifecycle? status?]]))
+   [com.palletops.leaven.protocols :refer [startable? stoppable? queryable?]]))
 
-(def ILifecycle
-  (schema/pred lifecycle? "lifecycle?"))
+(def Startable
+  (schema/pred startable? "startable?"))
 
-(def IStatus
-  (schema/pred status? "status?"))
+(def Stoppable
+  (schema/pred stoppable? "stoppable?"))
+
+(def Queryable
+  (schema/pred queryable? "status?"))

--- a/test/com/palletops/leaven/schema_test.cljx
+++ b/test/com/palletops/leaven/schema_test.cljx
@@ -1,8 +1,8 @@
 (ns com.palletops.leaven.schema-test
   #+clj
   (:require
-   [com.palletops.leaven :refer [defsystem lifecycle? status?]]
-   [com.palletops.leaven.schema :refer [ILifecycle IStatus]]
+   [com.palletops.leaven :refer [defsystem startable? stoppable? queryable?]]
+   [com.palletops.leaven.schema :refer [Startable Stoppable Queryable]]
    [schema.core :as schema]
    [clojure.test :refer [is deftest testing]])
   #+cljs
@@ -11,21 +11,25 @@
    [com.palletops.leaven :refer [defsystem]])
   #+cljs
   (:require
-   [com.palletops.leaven :refer [lifecycle? status?]]
-   [com.palletops.leaven.schema :refer [ILifecycle IStatus]]
+   [com.palletops.leaven :refer [startable? stoppable? queryable?]]
+   [com.palletops.leaven.schema :refer [Startable Stoppable Queryable]]
    [cemerick.cljs.test :as t]
    [schema.core :as schema]))
 
 (defsystem A [])
 
 (deftest schema-test
-  (is (lifecycle? (->A)))
-  (is (status? (->A)))
+  (is (startable? (->A)))
+  (is (stoppable? (->A)))
+  (is (queryable? (->A)))
   (testing "success"
-    (is (schema/validate ILifecycle (->A)))
-    (is (schema/validate IStatus (->A))))
+    (is (schema/validate Startable (->A)))
+    (is (schema/validate Stoppable (->A)))
+    (is (schema/validate Queryable (->A))))
   (testing "failure"
     (is (thrown? #+cljs js/Error #+clj Exception
-                 (schema/validate ILifecycle {})))
+                 (schema/validate Startable {})))
     (is (thrown? #+cljs js/Error #+clj Exception
-                 (schema/validate IStatus {})))))
+                 (schema/validate Stoppable {})))
+    (is (thrown? #+cljs js/Error #+clj Exception
+                 (schema/validate Queryable {})))))

--- a/test/com/palletops/leaven_test.cljx
+++ b/test/com/palletops/leaven_test.cljx
@@ -2,7 +2,7 @@
   #+clj
   (:require
    [com.palletops.leaven :as leaven :refer [start stop defsystem]]
-   [com.palletops.leaven.protocols :refer [ILifecycle]]
+   [com.palletops.leaven.protocols :refer [Startable Stoppable]]
    [clojure.test :refer [is deftest testing]])
   #+cljs
   (:require-macros
@@ -11,12 +11,13 @@
   #+cljs
   (:require
    [com.palletops.leaven :as leaven :refer [start stop]]
-   [com.palletops.leaven.protocols :as impl :refer [ILifecycle]]
+   [com.palletops.leaven.protocols :as impl :refer [Startable Stoppable]]
    [cemerick.cljs.test :as t]))
 
 (defrecord TestA [s]
-  ILifecycle
+  Startable
   (start [c] c)
+  Stoppable
   (stop [c] c))
 
 (deftest x
@@ -25,8 +26,9 @@
     (is (= a (stop a)))))
 
 (defrecord TestB [start-a stop-a v]
-  ILifecycle
+  Startable
   (start [c] (update-in c [:start-a] swap! (fnil conj []) v))
+  Stoppable
   (stop [c] (update-in c [:stop-a] swap! (fnil conj []) v)))
 
 (defsystem TestSystem [:b1 :b2])
@@ -48,8 +50,9 @@
       (is (= [:b2 :b1] @stop-a)) "Stops in reverse order")))
 
 (defrecord TestThrow []
-  ILifecycle
+  Startable
   (start [c] (throw (ex-info "start-failed" {})))
+  Stoppable
   (stop [c] (throw (ex-info "stop-failed" {}))))
 
 (defn test-throw-system []


### PR DESCRIPTION
Allow components to implement `start` and `stop` individually as required.

Closes #1
