### PR TITLE
In defsystem, move user-provided protocol implementations after the generic ones

### DIFF
--- a/src/cljx/com/palletops/leaven.cljx
+++ b/src/cljx/com/palletops/leaven.cljx
@@ -208,7 +208,6 @@
     `(do
        (def ~option-sym ~options) ; defrecord functions can't access lexical scope
        (defrecord ~record-name [~@component-syms]
-         ~@body
          protocols/Startable
          (~'start [component#]
            (apply-components
@@ -220,4 +219,5 @@
          protocols/Queryable
          (~'status [component#]
            (apply-components
-            status component# ~rcomponents "querying status" nil))))))
+            status component# ~rcomponents "querying status" nil))
+         ~@body))))


### PR DESCRIPTION
This allows the user to provide their own versions of `start`, `stop`, or `status` for systems. For my use case, I have code that depends on the system being initialized, so I want to provide a custom `status` method that checks specific things. 

This behaviour seems to be allowed by vanilla `defrecord` - here's an example, with my version of Leaven installed locally:

``` clojure
user> (defprotocol Speak
        (say [this]))
Speak
user> (defrecord NewThing [attr]
        Speak
        (say [this] "woo")
        Speak
        (say [this] "boo"))
user.NewThing
user> (say (->NewThing 5))
"boo"
user=> (use 'com.palletops.leaven)
nil
user=> (defsystem TestingOut [config connection]
         {:depends {:connection [:config]}}
         com.palletops.leaven.protocols/Queryable
         (status [component] (if connection :started :stopped)))
user.TestingOut
user=> (status (map->TestingOut {:config :true}))
:stopped
user=> (status (map->TestingOut {:config :true :connection {:fake true}}))
:started
```

I realize that I could just make a plain record and implement the Leaven protocols myself, but I would like to rely on the other nice default behaviours of `defsystem` :)
